### PR TITLE
Add Spanish header and background styling

### DIFF
--- a/MindTrack/MindTrack/ContentView.swift
+++ b/MindTrack/MindTrack/ContentView.swift
@@ -8,14 +8,56 @@
 import SwiftUI
 
 struct ContentView: View {
+    private var fechaFormateada: String {
+        DateFormatter.esES.string(from: Date())
+    }
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        ZStack {
+            VStack(alignment: .leading) {
+                Text("Hoy")
+                    .font(.system(size: 58, weight: .heavy))
+                Text(fechaFormateada)
+                    .font(.system(size: 22, weight: .regular))
+                    .opacity(0.85)
+                Spacer()
+            }
+            .foregroundColor(.black)
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
-        .padding()
+        .background(Color(hex: "F5ECE9"))
+        .ignoresSafeArea()
+    }
+}
+
+private extension DateFormatter {
+    static let esES: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "es-ES")
+        formatter.dateStyle = .long
+        formatter.timeStyle = .none
+        return formatter
+    }()
+}
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int = UInt64()
+        Scanner(string: hex).scanHexInt64(&int)
+        let r, g, b: UInt64
+        switch hex.count {
+        case 6:
+            r = (int >> 16) & 0xFF
+            g = (int >> 8) & 0xFF
+            b = int & 0xFF
+        default:
+            r = 0
+            g = 0
+            b = 0
+        }
+        self.init(.sRGB, red: Double(r) / 255, green: Double(g) / 255, blue: Double(b) / 255, opacity: 1)
     }
 }
 


### PR DESCRIPTION
## Summary
- Wrap ContentView in ZStack with beige background and safe-area ignoring
- Display "Hoy" and localized Spanish date in black text
- Add helper DateFormatter and Color hex initializer, using es-ES locale with no time component

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68994dd503508330bdc358f721d24e71