### PR TITLE
Add next task label and add task button

### DIFF
--- a/MindTrack/MindTrack/Color+Hex.swift
+++ b/MindTrack/MindTrack/Color+Hex.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import Foundation
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (255, 0, 0, 0)
+        }
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}

--- a/MindTrack/MindTrack/ContentView.swift
+++ b/MindTrack/MindTrack/ContentView.swift
@@ -10,10 +10,46 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+            VStack {
+                Image(systemName: "globe")
+                    .imageScale(.large)
+                    .foregroundStyle(.tint)
+                Text("Hello, world!")
+            }
+
+            Text("Siguiente Tarea en 10 h")
+                .font(.headline)
+                .padding(.top, 20)
+
+            Button(action: {
+                // Acción para añadir tarea
+            }) {
+                HStack {
+                    Circle()
+                        .fill(Color.white)
+                        .frame(width: 22, height: 22)
+                        .overlay(
+                            Circle()
+                                .stroke(Color.black, lineWidth: 2)
+                        )
+                        .overlay(
+                            Image(systemName: "plus")
+                                .foregroundColor(.black)
+                        )
+
+                    Text("AÑADIR TAREA")
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(.black)
+                }
+                .frame(height: 40)
+                .frame(maxWidth: .infinity)
+                .background(Color(hex: "E8674D").opacity(0.9))
+                .cornerRadius(14)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .stroke(Color.black, lineWidth: 2)
+                )
+            }
         }
         .padding()
     }


### PR DESCRIPTION
## Summary
- Show next task countdown text
- Add "AÑADIR TAREA" button with custom styling
- Support hex color initialization with Foundation import

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `xcodebuild -project MindTrack/MindTrack.xcodeproj -scheme MindTrack -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_6899563920c48330aae1ed52dd35d087