### PR TITLE
Layout ContentView with rail and padded scroll

### DIFF
--- a/MindTrack/MindTrack/ContentView.swift
+++ b/MindTrack/MindTrack/ContentView.swift
@@ -9,13 +9,28 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        HStack(alignment: .top, spacing: 0) {
+            SolarRailView()
+                .frame(width: 36)
+
+            Spacer()
+                .frame(width: 16)
+
+            ScrollView {
+                VStack(spacing: 16) {
+                    EmptyView()
+                }
+            }
+            .padding(.top, 6)
+            .padding(.horizontal, 18)
+            .padding(.bottom, 160)
         }
-        .padding()
+    }
+}
+
+struct SolarRailView: View {
+    var body: some View {
+        Color.clear
     }
 }
 


### PR DESCRIPTION
## Summary
- Rework ContentView layout using a left rail and scrollable content area
- Add placeholder `SolarRailView` and apply top, horizontal, and bottom padding to the scroll view

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project MindTrack/MindTrack.xcodeproj -scheme MindTrack -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68995aa14c6c8330a07849f7991b5238