### PR TITLE
Add Spanish locale formatting and conditional header

### DIFF
--- a/MindTrack/MindTrack/ContentView.swift
+++ b/MindTrack/MindTrack/ContentView.swift
@@ -8,14 +8,46 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var selectedDate = Date()
+    private let localeES = Locale(identifier: "es_ES")
+    
+    private var timeFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = localeES
+        formatter.dateFormat = "h:mm a"
+        formatter.amSymbol = "am"
+        formatter.pmSymbol = "pm"
+        return formatter
+    }
+
     var body: some View {
         VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+            headerView
+            
+            DatePicker("", selection: $selectedDate, displayedComponents: .date)
+                .datePickerStyle(.graphical)
+
+            List(sampleTimes, id: \.self) { date in
+                Text(timeFormatter.string(from: date))
+            }
         }
         .padding()
+    }
+
+    private var headerView: some View {
+        if Calendar.current.isDateInToday(selectedDate) {
+            Text("Hoy")
+        } else {
+            Text(selectedDate.formatted(.dateTime.weekday(.wide).locale(localeES)))
+        }
+    }
+
+    private var sampleTimes: [Date] {
+        [
+            Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: selectedDate)!,
+            Calendar.current.date(bySettingHour: 13, minute: 30, second: 0, of: selectedDate)!,
+            Calendar.current.date(bySettingHour: 18, minute: 15, second: 0, of: selectedDate)!,
+        ]
     }
 }
 


### PR DESCRIPTION
## Summary
- Show "Hoy" when the selected date is today, otherwise display weekday name in Spanish
- Format card times with a DateFormatter using `es_ES` locale and custom AM/PM symbols

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68995bf8422c8330a24768887a769310