### PR TITLE
Add SunTimes manager and night state to solar rail view

### DIFF
--- a/MindTrack/MindTrack/ContentView.swift
+++ b/MindTrack/MindTrack/ContentView.swift
@@ -1,21 +1,17 @@
-//
-//  ContentView.swift
-//  MindTrack
-//
-//  Created by Jorge Carrasco on 9/08/25.
-//
-
 import SwiftUI
+import CoreLocation
 
 struct ContentView: View {
+    @State private var isNight = false
+    private let sunManager = SunTimesManager()
+    private let location = CLLocation(latitude: 0, longitude: 0)
+    
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
-        .padding()
+        SolarRailView(isNight: isNight)
+            .task {
+                isNight = await sunManager.isNight(at: Date(), location: location)
+            }
+            .padding()
     }
 }
 

--- a/MindTrack/MindTrack/SolarRailView.swift
+++ b/MindTrack/MindTrack/SolarRailView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct SolarRailView: View {
+    var isNight: Bool
+    
+    var body: some View {
+        VStack {
+            Image(systemName: isNight ? "moon.stars.fill" : "sun.max.fill")
+                .font(.largeTitle)
+                .foregroundColor(isNight ? .white : .yellow)
+            Rectangle()
+                .frame(width: 2, height: 100)
+                .foregroundColor(.clear)
+                .overlay(
+                    Rectangle()
+                        .stroke(style: StrokeStyle(lineWidth: 2, dash: [5]))
+                        .foregroundColor(isNight ? .gray : .orange)
+                )
+        }
+    }
+}
+
+#Preview {
+    SolarRailView(isNight: false)
+}

--- a/MindTrack/MindTrack/SunTimesManager.swift
+++ b/MindTrack/MindTrack/SunTimesManager.swift
@@ -1,0 +1,25 @@
+import Foundation
+import WeatherKit
+import CoreLocation
+
+struct SunTimesManager {
+    private let service = WeatherService.shared
+    private let calendar = Calendar.current
+    
+    func sunset(for day: Date, location: CLLocation) async -> Date {
+        do {
+            let daily = try await service.weather(for: location, including: .daily)
+            if let sunset = daily.forecast.first?.sun.sunset {
+                return sunset
+            }
+        } catch {
+            // Fallback handled below
+        }
+        return calendar.date(bySettingHour: 18, minute: 0, second: 0, of: day) ?? day
+    }
+    
+    func isNight(at date: Date = Date(), location: CLLocation) async -> Bool {
+        let sunsetTime = await sunset(for: date, location: location)
+        return date >= sunsetTime
+    }
+}


### PR DESCRIPTION
## Summary
- add SunTimesManager to fetch sunset using WeatherKit with a 6pm fallback
- toggle SolarRailView between day and night graphics using SunTimesManager
- calculate `isNight` in ContentView and pass to SolarRailView

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68995ca503ac83309cd377696d6b4ff6