### PR TITLE
Improve accessibility attributes and text scaling

### DIFF
--- a/MindTrack/MindTrack/ContentView.swift
+++ b/MindTrack/MindTrack/ContentView.swift
@@ -13,7 +13,20 @@ struct ContentView: View {
             Image(systemName: "globe")
                 .imageScale(.large)
                 .foregroundStyle(.tint)
+                .border(Color.black)
+                .accessibilityLabel("Globe icon")
+                .accessibilityHint("Represents the world.")
+            Button(action: {}) {
+                Text("Start")
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .border(Color.black)
+            .accessibilityLabel("Start button")
+            .accessibilityHint("Begins tracking.")
             Text("Hello, world!")
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
         }
         .padding()
     }


### PR DESCRIPTION
## Summary
- add accessibility labels and hints to main icon and button
- rely on black borders instead of shadows
- ensure texts scale with `.minimumScaleFactor(0.8)` and `lineLimit(1)`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689960502f848330a472d60b374a436e